### PR TITLE
More tweaks

### DIFF
--- a/EnforcerMod_VS/Assets.cs
+++ b/EnforcerMod_VS/Assets.cs
@@ -151,7 +151,7 @@ namespace EnforcerPlugin
 
             Shader hotpoo = Resources.Load<Shader>("Shaders/Deferred/hgstandard");
 
-            string portraitString = Random.value > 0.1f ? "texEnforcerIcon" : "texEnforcerIconEpic";
+            string portraitString = Random.value > 0.01f ? "texEnforcerIcon" : "texEnforcerIconEpic";
             charPortrait = MainAssetBundle.LoadAsset<Sprite>(portraitString).texture;
             nemCharPortrait = MainAssetBundle.LoadAsset<Sprite>("nemIconBlu").texture;
             nemBossPortrait = MainAssetBundle.LoadAsset<Sprite>("nemIconRed").texture;

--- a/EnforcerMod_VS/EnforcerMain.cs
+++ b/EnforcerMod_VS/EnforcerMain.cs
@@ -12,8 +12,8 @@ namespace EntityStates.Enforcer
     public class EnforcerMain : GenericCharacterMain
     {
         public static event Action<bool> onDance = delegate { };
-        public static Vector3 shieldCameraPosition = new Vector3(1.8f, -2.4f, -6f);
-        public static Vector3 standardCameraPosition = new Vector3(0f, -1.3f, -12f);
+        public static Vector3 shieldCameraPosition = new Vector3(1.8f, -2.4f, -5f);
+        public static Vector3 standardCameraPosition = new Vector3(0f, -1.3f, -10f);
         public static bool shotgunToggle = false;
 
         public Transform origOrigin;

--- a/EnforcerMod_VS/EnforcerModPlugin.cs
+++ b/EnforcerMod_VS/EnforcerModPlugin.cs
@@ -1490,9 +1490,10 @@ namespace EnforcerPlugin {
             stunGrenadeImpact.lifetimeRandomOffset = 0;
             stunGrenadeImpact.blastRadius = 8;
             stunGrenadeImpact.blastDamageCoefficient = 1;
-            stunGrenadeImpact.blastProcCoefficient = 0.6f;
+            stunGrenadeImpact.blastProcCoefficient = 1f;
             stunGrenadeImpact.fireChildren = false;
             stunGrenadeImpact.childrenCount = 0;
+            stunGrenadeImpact.bonusBlastForce = -2000f * Vector3.up;
             stunGrenadeController.procCoefficient = 1;
 
             shockGrenade = Resources.Load<GameObject>("Prefabs/Projectiles/CommandoGrenadeProjectile").InstantiateClone("EnforcerShockGrenade", true);
@@ -1517,9 +1518,10 @@ namespace EnforcerPlugin {
             shockGrenadeImpact.lifetimeRandomOffset = 0;
             shockGrenadeImpact.blastRadius = 14f;
             shockGrenadeImpact.blastDamageCoefficient = 1;
-            shockGrenadeImpact.blastProcCoefficient = 0.6f;
+            shockGrenadeImpact.blastProcCoefficient = 1f;
             shockGrenadeImpact.fireChildren = false;
             shockGrenadeImpact.childrenCount = 0;
+            shockGrenadeImpact.bonusBlastForce = -2000f * Vector3.up;
             shockGrenadeImpact.impactEffect = Resources.Load<GameObject>("Prefabs/Effects/ImpactEffects/LightningStrikeImpact");
             shockGrenadeController.procCoefficient = 1;
 
@@ -2240,7 +2242,7 @@ namespace EnforcerPlugin {
             //string desc = $"Fire a burst of bullets dealing {damage}. <style=cIsUtility>During Protect and Serve</style>, fires <style=cIsDamage>{2 * FireBurstRifle.projectileCount} bullets</style> instead.";
 
             string damage = $"<style=cIsDamage>{100f * FireMachineGun.damageCoefficient}% damage</style>";
-            string desc = $"<style=cIsHealth>Slow yourself down</style> and suppress enemies for {damage}.";
+            string desc = $"Unload a barrage of bullets into enemies for {damage}. While shielded, <style=cIsHealth>slow yourself down</style>.";
 
             LanguageAPI.Add("ENFORCER_PRIMARY_RIFLE_NAME", "Heavy Machinegun");
             LanguageAPI.Add("ENFORCER_PRIMARY_RIFLE_DESCRIPTION", desc);
@@ -2410,7 +2412,7 @@ namespace EnforcerPlugin {
         private SkillDef SpecialSkillDef_ProtectAndServe()
         {
             LanguageAPI.Add("ENFORCER_SPECIAL_SHIELDUP_NAME", "Protect and Serve");
-            LanguageAPI.Add("ENFORCER_SPECIAL_SHIELDUP_DESCRIPTION", "Take a defensive stance, <style=cIsUtility>blocking all damage from the front</style>. <style=cIsDamage>Increases your rate of fire</style>, but <style=cIsUtility>prevents sprinting and jumping</style>.");
+            LanguageAPI.Add("ENFORCER_SPECIAL_SHIELDUP_DESCRIPTION", "Take a defensive stance, <style=cIsUtility>blocking all damage from the front</style>. <style=cIsDamage>Increases your rate of fire</style>, but <style=cIsHealth>prevents sprinting and jumping</style>.");
 
             SkillDef mySkillDef = ScriptableObject.CreateInstance<SkillDef>();
             mySkillDef.activationState = new SerializableEntityStateType(typeof(ProtectAndServe));

--- a/EnforcerMod_VS/States/FireMachineGun.cs
+++ b/EnforcerMod_VS/States/FireMachineGun.cs
@@ -29,9 +29,10 @@ namespace EntityStates.Enforcer
         {
             base.OnEnter();
 
-            if (base.characterBody)
+            isShielded = HasBuff(EnforcerPlugin.Modules.Buffs.protectAndServeBuff) || HasBuff(EnforcerPlugin.Modules.Buffs.energyShieldBuff);
+            if (NetworkServer.active)
             {
-                if (NetworkServer.active)
+                if (isShielded && base.characterBody)
                 {
                     base.characterBody.AddBuff(RoR2Content.Buffs.Slow50);
                 }
@@ -42,7 +43,6 @@ namespace EntityStates.Enforcer
         private void FireBullet()
         {
             characterBody.SetAimTimer(2f);
-            isShielded = HasBuff(EnforcerPlugin.Modules.Buffs.protectAndServeBuff) || HasBuff(EnforcerPlugin.Modules.Buffs.energyShieldBuff);
             duration = FireMachineGun.baseDuration / base.characterBody.attackSpeed * (isShielded ? 0.8f : 1f);
             firingStopwatch = 0f;
 
@@ -101,7 +101,7 @@ namespace EntityStates.Enforcer
                     smartCollision = false,
                     procChainMask = default,
                     procCoefficient = 1f,
-                    radius = 0.5f,
+                    radius = 0.3f,
                     sniper = false,
                     stopperMask = LayerIndex.CommonMasks.bullet,
                     weapon = null,
@@ -113,8 +113,9 @@ namespace EntityStates.Enforcer
                     HitEffectNormal = false
                 }.Fire();
 
+                float scaledRecoil = recoilAmplitude / base.characterBody.attackSpeed;
                 base.characterBody.AddSpreadBloom(FireMachineGun.bloom * shieldSpreadMult);
-                base.AddRecoil(-0.4f * recoilAmplitude, -0.8f * recoilAmplitude, -0.3f * recoilAmplitude, 0.3f * recoilAmplitude);
+                base.AddRecoil(-0.4f * scaledRecoil, -0.8f * scaledRecoil, -0.3f * scaledRecoil, 0.3f * scaledRecoil);
             }
         }
 
@@ -137,7 +138,7 @@ namespace EntityStates.Enforcer
 
         public override void OnExit()
         {
-            if (base.characterBody && NetworkServer.active)
+            if (NetworkServer.active && isShielded && base.characterBody)
             {
                 base.characterBody.RemoveBuff(RoR2Content.Buffs.Slow50);
             }

--- a/EnforcerMod_VS/States/Primary.cs
+++ b/EnforcerMod_VS/States/Primary.cs
@@ -83,7 +83,7 @@ namespace EntityStates.Enforcer.NeutralSpecial {
 
                 Util.PlayAttackSpeedSound(soundString, gameObject, attackSpeedStat);
 
-                float recoilAmplitude = bulletRecoil;
+                float recoilAmplitude = bulletRecoil / this.attackSpeedStat;
 
                 if (HasBuff(EnforcerPlugin.Modules.Buffs.protectAndServeBuff) || HasBuff(EnforcerPlugin.Modules.Buffs.energyShieldBuff)) recoilAmplitude = shieldedBulletRecoil;
 
@@ -131,14 +131,14 @@ namespace EntityStates.Enforcer.NeutralSpecial {
                         procCoefficient = procCoefficient,
                         radius = thiccness,
                         sniper = false,
-                        stopperMask = LayerIndex.world.collisionMask,
+                        stopperMask = LayerIndex.world.mask,
                         weapon = null,
                         tracerEffectPrefab = tracerEffect,
                         spreadPitchScale = 1f,
                         spreadYawScale = 1f,
                         queryTriggerInteraction = QueryTriggerInteraction.UseGlobal,
-                        hitEffectPrefab = ClayBruiser.Weapon.MinigunFire.bulletHitEffectPrefab,
-                        HitEffectNormal = ClayBruiser.Weapon.MinigunFire.bulletHitEffectNormal
+                        hitEffectPrefab = Commando.CommandoWeapon.FireBarrage.hitEffectPrefab,
+                        HitEffectNormal = false
                     };
 
                     bulletAttack.minSpread = 0;

--- a/EnforcerMod_VS/States/PrimarySuper.cs
+++ b/EnforcerMod_VS/States/PrimarySuper.cs
@@ -92,7 +92,7 @@ namespace EntityStates.Enforcer {
 
                 Util.PlayAttackSpeedSound(soundString, base.gameObject, this.attackSpeedStat);
 
-                float recoilAmplitude = RiotShotgun.bulletRecoil;
+                float recoilAmplitude = RiotShotgun.bulletRecoil / this.attackSpeedStat;
 
                 if (base.HasBuff(EnforcerPlugin.Modules.Buffs.protectAndServeBuff) || base.HasBuff(EnforcerPlugin.Modules.Buffs.energyShieldBuff)) recoilAmplitude = RiotShotgun.shieldedBulletRecoil;
 
@@ -138,7 +138,7 @@ namespace EntityStates.Enforcer {
                         spreadPitchScale = 1f,  //old: 21 spread 0.3f
                         spreadYawScale = 1f,    //old: 21 spread 0.7f
                         queryTriggerInteraction = QueryTriggerInteraction.UseGlobal,
-                        hitEffectPrefab = Commando.CommandoWeapon.FireShotgun.hitEffectPrefab,//ClayBruiser.Weapon.MinigunFire.bulletHitEffectPrefab,
+                        hitEffectPrefab = Commando.CommandoWeapon.FireBarrage.hitEffectPrefab,
                         HitEffectNormal = ClayBruiser.Weapon.MinigunFire.bulletHitEffectNormal
                     };
 
@@ -163,14 +163,21 @@ namespace EntityStates.Enforcer {
                     bulletAttack.maxSpread = 0f;
                     bulletAttack.Fire();
 
-                    bullets -= 7;
-                    bulletAttack.bulletCount = 7;
+                    bullets -= 3;
+                    bulletAttack.bulletCount = 3;
+                    bulletAttack.minSpread = 0f;
+                    bulletAttack.maxSpread = this.bulletSpread / 2f;
+                    bulletAttack.Fire();
+
+                    bullets -= 3;
+                    bulletAttack.bulletCount = 3;
                     bulletAttack.minSpread = 0f;
                     bulletAttack.maxSpread = this.bulletSpread;
                     bulletAttack.Fire();
 
                     if (bullets > 0)
                     {
+                        bulletAttack.bulletCount = (uint)bullets;
                         bulletAttack.spreadPitchScale = 1f;
                         bulletAttack.spreadYawScale = 2.3f;
                         bulletAttack.minSpread = this.bulletSpread / bulletAttack.spreadYawScale;

--- a/EnforcerMod_VS/States/UtilityAlt.cs
+++ b/EnforcerMod_VS/States/UtilityAlt.cs
@@ -55,7 +55,7 @@ namespace EntityStates.Enforcer
                     damage = StunGrenade.damageCoefficient * this.damageStat,
                     damageColorIndex = DamageColorIndex.Default,
                     damageTypeOverride = DamageType.Stun1s,
-                    force = 2000,
+                    force = 0f,
                     owner = base.gameObject,
                     position = aimRay.origin,
                     procChainMask = default(ProcChainMask),

--- a/EnforcerMod_VS/States/UtilityScepter.cs
+++ b/EnforcerMod_VS/States/UtilityScepter.cs
@@ -72,11 +72,11 @@ namespace EntityStates.Enforcer
 
     public class ShockGrenade : BaseSkillState
     {
-        public static float baseDuration = 0.75f;
-        public static float damageCoefficient = 7f;
+        public static float baseDuration = 0.5f;
+        public static float damageCoefficient = 7.2f;
         public static float procCoefficient = 1f;
         public static float bulletRecoil = 2.5f;
-        public static float projectileSpeed = 90f;
+        public static float projectileSpeed = 75f;
 
         //TODO: why did fucking "grenademuzzle" break here but not in the others?
         public static string muzzleString = "Muzzle";
@@ -114,19 +114,26 @@ namespace EntityStates.Enforcer
                 Debug.LogWarning(childLocator);
 
                 Debug.LogWarning(childLocator.FindChild(ShockGrenade.muzzleString));
+
                 Ray aimRay = base.GetAimRay();
+                Vector3 aimTweak;
+
+                Vector3 aimCross = Vector3.Cross(aimRay.direction, Vector3.up).normalized;
+                Vector3 aimUpPerpendicular = Vector3.Cross(aimCross, aimRay.direction).normalized;
+                aimTweak = aimUpPerpendicular;
+
                 FireProjectileInfo info = new FireProjectileInfo()
                 {
                     crit = base.RollCrit(),
                     damage = ShockGrenade.damageCoefficient * this.damageStat,
                     damageColorIndex = DamageColorIndex.Default,
                     damageTypeOverride = DamageType.Shock5s,
-                    force = 250,
+                    force = 0f,
                     owner = base.gameObject,
-                    position = childLocator.FindChild(ShockGrenade.muzzleString).position,
+                    position = aimRay.origin,
                     procChainMask = default(ProcChainMask),
                     projectilePrefab = EnforcerPlugin.EnforcerModPlugin.shockGrenade,
-                    rotation = Quaternion.LookRotation(base.GetAimRay().direction),
+                    rotation = RoR2.Util.QuaternionSafeLookRotation(aimRay.direction + aimTweak * 0.08f),
                     useFuseOverride = false,
                     useSpeedOverride = true,
                     speedOverride = ShockGrenade.projectileSpeed,


### PR DESCRIPTION
- Adjusted camera.
- Recoil for all primaries now scales downwards with attack speed.

- Super shotgun bullet spread distribution tweaked.
- Fixed purple hit effects.

- HMG now only slows while shielded.
- HMG bullet radius reduced 0.5 -> 0.3

Stun Grenades:
- Force reduced 2000 -> 0
- Now knocks flying enemies downwards with 2000 force.
- Increased proc coefficient to 1.0 for real.
- Fixed Shock Grenade trajectory being different from Stun Grenades.